### PR TITLE
Fix for a bug resulting in a startup crash for Android Release builds

### DIFF
--- a/src/color-matrix-filter.js
+++ b/src/color-matrix-filter.js
@@ -25,7 +25,7 @@ ColorMatrixFilter.isColorMatrixFilter = true;
 ColorMatrixFilter.displayName = 'ColorMatrix';
 
 const filterName = (name) => {
-  const [first, ...rest] = name;
+  const [first, ...rest] = name.split('');
   return name === 'rgba' ? 'RGBA' : first.toUpperCase() + rest.join('');
 };
 


### PR DESCRIPTION
This PR fixes the startup crash for Android Release Builds. This is probably related to the polyfill in Babel for String destructuring.

com.facebook.react.common.JavascriptException: Invalid attempt to destructure non-iterable instance, stack:
  at ./node_modules/react-native/Libraries/polyfills/babelHelpers.js:491:22
  at toConsumableArray (./node_modules/react-native/Libraries/polyfills/babelHelpers.js:556:13)
  **at name (./node_modules/react-native-color-matrix-image-filters/src/color-matrix-filter.js:28:27)**
  at name (./node_modules/react-native-color-matrix-image-filters/src/color-matrix-filter.js:64:27)
  at ./node_modules/react-native-color-matrix-image-filters/src/color-matrix-filter.js:63:2
  at factory (./node_modules/metro/src/lib/polyfills/require.js:242:13)
  ...
 
