### PR TITLE
(fix): add field "react-native" to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   ],
   "license": "MIT",
   "main": "dist/index.js",
+  "react-native": "src/index.ts",
   "types": "dist/index.d.ts",
   "name": "react-native-color-matrix-image-filters",
   "author": "iyegoroff <iegoroff@gmail.com>",


### PR DESCRIPTION
This PR fixes issue  https://github.com/iyegoroff/react-native-color-matrix-image-filters/issues/114