### PR TITLE
(fix) iOS 17.4 simulator crash

### DIFF
--- a/ios/CMIFColorMatrixImageFilter.mm
+++ b/ios/CMIFColorMatrixImageFilter.mm
@@ -209,9 +209,9 @@ static CIContext* context;
 }
 
 + (CIContext *)createContextWithOptions:(nullable NSDictionary<NSString *, id> *)options
-  {
-    return [CIContext contextWithOptions:options];
-  }
+{
+  return [CIContext contextWithOptions:options];
+}
 
 #ifdef RCT_NEW_ARCH_ENABLED
 + (ComponentDescriptorProvider)componentDescriptorProvider

--- a/ios/CMIFColorMatrixImageFilter.mm
+++ b/ios/CMIFColorMatrixImageFilter.mm
@@ -209,12 +209,9 @@ static CIContext* context;
 }
 
 + (CIContext *)createContextWithOptions:(nullable NSDictionary<NSString *, id> *)options
-{
-  EAGLContext *eaglContext = [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES3];
-  eaglContext = eaglContext ?: [[EAGLContext alloc] initWithAPI:kEAGLRenderingAPIOpenGLES2];
-
-  return [CIContext contextWithEAGLContext:eaglContext options:options];
-}
+  {
+    return [CIContext contextWithOptions:options];
+  }
 
 #ifdef RCT_NEW_ARCH_ENABLED
 + (ComponentDescriptorProvider)componentDescriptorProvider


### PR DESCRIPTION
I'm not a native iOS developer, but this PR seems to fix issue #126.

OpenGL context is deprecated and since we only use our context to render images, `contextWithOptions` should work, as [per documentation](https://developer.apple.com/documentation/coreimage/cicontext/1438261-initwithoptions).