### PR TITLE
Fix crash with react native 0.80+

### DIFF
--- a/ios/CMIFColorMatrixImageFilter.mm
+++ b/ios/CMIFColorMatrixImageFilter.mm
@@ -220,4 +220,8 @@ Class<RCTComponentViewProtocol> CMIFColorMatrixImageFilterCls(void)
 }
 #endif
 
+- (void)setMatrix:(NSArray<NSNumber *> *)matrix {
+  [self updateFilter:matrix];
+}
+
 @end


### PR DESCRIPTION
Fixes a crash due to a missing `setMatrix` setter method. I'm a bit green with iOS development in general so happy to make any adjustments necessary!

Fixes #144